### PR TITLE
[GIT] Submodule: fix setup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "/js/bimsurfer"]
-	path = /js/bimsurfer
-	url = https://github.com/opensourceBIM/BIMsurfer.git
 [submodule "js/bimsurfer"]
 	path = js/bimsurfer
 	url = https://github.com/opensourceBIM/BIMsurfer.git

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ if you do a plain checkout your missing the bimsurfer package (wich is implement
 to utilize this do the following:
 
     $ cd <Path to bimvie.ws>
+    $ git submodule init
     $ git submodule update
     Cloning into 'js/bimsurfer'...
     remote: Reusing existing pack: 3329, done.


### PR DESCRIPTION
When I tried the instructions given in `README.md` to setup the project after a git clone, it doesn't work for an unknown reason.

Thanks to this explanation:
https://stackoverflow.com/questions/3336995/git-will-not-init-sync-update-new-submodules#answer-33369709
I achieved to setup correctly the `bimsurfer` submodule.

In this PR, I just propose the fix and the update of the `README.md`.