### PR TITLE
Update and add IFC documentation URL patterns for IFC4 and IFC4x3

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -60,17 +60,17 @@ function Browser(containerDiv, project, revision) {
 					var schema = project.schema;
 					var typeDef = Global.bimServerApi.schemas[schema][object.getType()];
 					var baseUrl = null;
-					var docURL = null;
+					var docUrl = null;
 
 					if (schema == "ifc2x3tc1") {
 						baseUrl = "https://standards.buildingsmart.org/IFC/RELEASE/IFC2x3/TC1/HTML/";
-						docURL = baseUrl + typeDef.domain + "/lexical/" + object.getType().toLowerCase() + ".htm";
+						docUrl = baseUrl + typeDef.domain + "/lexical/" + object.getType().toLowerCase() + ".htm"
 					} else if (schema == "ifc4") {
 						baseUrl = "https://standards.buildingsmart.org/IFC/RELEASE/IFC4/ADD2_TC1/HTML/";
-						docURL = baseURL + "/link/" + object.getType().toLowerCase() + ".htm";
+						docUrl = baseUrl + "/link/" + object.getType().toLowerCase() + ".htm";
 					} else if (schema == "ifc4x3") {
 						baseUrl = "https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/";
-						docURL = baseUrl + "/lexical/" + object.getType() + ".htm";
+						docUrl = baseUrl + "/lexical/" + object.getType() + ".htm";
 					}
 
 					containerDiv.find(".objectTable tbody").append("<tr class=\"extra\"><td>Type</td><td><a target=\"_blank\" href=\"" + docUrl + "\">" + object.getType() + "</a></td></tr>");


### PR DESCRIPTION
Fixed #132 

**Changes:**

- Updated the base URL for ifc4 to point to the correct ADD2_TC1 version.
- Added the correct URL pattern for ifc4x3.
- Removed .toLowerCase() for ifc4x3 to ensure accurate URL generation.